### PR TITLE
Don't force the use of "http" to load resources (css, images, etc)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title:            Nim Weekly
 locale:           en_US
-url:              http://nimweekly.github.io
+url:              nimweekly.github.io
 
 
 # Jekyll configuration


### PR DESCRIPTION
Firefox will not show content from "http" when "https" is used to access
to the main page.
